### PR TITLE
fix: graceful shutdown of debug adapter on stop

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -1267,20 +1267,21 @@ func (d *Daemon) stopSession() {
 		_ = c.DisconnectRequest(true)
 		c.Close()
 	}
-	if d.adapterCmd != nil && d.adapterCmd.Process != nil {
+	cmd := d.adapterCmd
+	d.adapterCmd = nil
+	if cmd != nil && cmd.Process != nil {
 		// Give the adapter time to shut down gracefully before hard-killing
 		done := make(chan struct{})
 		go func() {
-			_ = d.adapterCmd.Wait()
+			_ = cmd.Wait()
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(3 * time.Second):
-			_ = d.adapterCmd.Process.Kill()
+			_ = cmd.Process.Kill()
 			<-done
 		}
-		d.adapterCmd = nil
 	}
 	if d.cleanupFn != nil {
 		d.cleanupFn()

--- a/daemon.go
+++ b/daemon.go
@@ -1268,8 +1268,18 @@ func (d *Daemon) stopSession() {
 		c.Close()
 	}
 	if d.adapterCmd != nil && d.adapterCmd.Process != nil {
-		_ = d.adapterCmd.Process.Kill()
-		_ = d.adapterCmd.Wait()
+		// Give the adapter time to shut down gracefully before hard-killing
+		done := make(chan struct{})
+		go func() {
+			_ = d.adapterCmd.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = d.adapterCmd.Process.Kill()
+			<-done
+		}
 		d.adapterCmd = nil
 	}
 	if d.cleanupFn != nil {

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -3,8 +3,10 @@ package dap
 import (
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOutputBufferBoundedAtWrite(t *testing.T) {
@@ -85,6 +87,50 @@ func TestTempBinaryCleanup_NilSafe(t *testing.T) {
 	// Verify stopSession with nil cleanupFn doesn't panic
 	d := &Daemon{}
 	d.stopSession() // should not panic
+}
+
+func TestStopSessionGracefulShutdown(t *testing.T) {
+	// Process that exits quickly on its own — should not need SIGKILL
+	cmd := exec.Command("sleep", "0")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{adapterCmd: cmd}
+
+	start := time.Now()
+	d.stopSession()
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("graceful shutdown took too long: %v (expected < 2s)", elapsed)
+	}
+	if d.adapterCmd != nil {
+		t.Error("adapterCmd should be nil after stopSession")
+	}
+}
+
+func TestStopSessionKillsHangingProcess(t *testing.T) {
+	// Process that ignores signals and hangs — should be killed after timeout
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{adapterCmd: cmd}
+
+	start := time.Now()
+	d.stopSession()
+	elapsed := time.Since(start)
+
+	// Should take ~3s (the timeout), not 60s
+	if elapsed > 5*time.Second {
+		t.Errorf("expected kill after ~3s, took %v", elapsed)
+	}
+	if elapsed < 2*time.Second {
+		t.Errorf("expected to wait for timeout, but finished in %v", elapsed)
+	}
+	if d.adapterCmd != nil {
+		t.Error("adapterCmd should be nil after stopSession")
+	}
 }
 
 func TestParseBreakpointSpec(t *testing.T) {


### PR DESCRIPTION
## Summary
- On `dap stop`, wait up to 3s for the debug adapter to exit gracefully after `DisconnectRequest(terminateDebuggee=true)` before resorting to SIGKILL
- Previously the adapter was hard-killed immediately, which could prevent clean debuggee shutdown

## Test plan
- [x] `TestStopSessionGracefulShutdown` — verifies fast-exiting processes aren't unnecessarily delayed
- [x] `TestStopSessionKillsHangingProcess` — verifies hanging processes get killed after 3s timeout
- [x] All existing tests pass (`make all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)