### PR TITLE
Fix debug program args after --

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -204,9 +204,23 @@ Blocks until the program hits a breakpoint or exits, then returns auto-context.`
   dap debug app.py -- --config prod.yaml --verbose
   dap debug --attach localhost:5678 --backend debugpy --break handler.py:15
   dap debug --pid 12345 --backend debugpy   # attach to running process`,
-		Args: cobra.MaximumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			scriptArgs := args
+			if dashIdx := cmd.ArgsLenAtDash(); dashIdx >= 0 && dashIdx <= len(args) {
+				scriptArgs = args[:dashIdx]
+			}
+			if len(scriptArgs) > 1 {
+				return fmt.Errorf("accepts at most 1 arg(s), received %d", len(scriptArgs))
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 && attach == "" && pid == 0 {
+			scriptArgs := args
+			if dashIdx := cmd.ArgsLenAtDash(); dashIdx >= 0 && dashIdx <= len(args) {
+				scriptArgs = args[:dashIdx]
+			}
+
+			if len(scriptArgs) == 0 && attach == "" && pid == 0 {
 				return fmt.Errorf("script path, --attach, or --pid required")
 			}
 
@@ -224,16 +238,13 @@ Blocks until the program hits a breakpoint or exits, then returns auto-context.`
 				ExceptionFilters: exceptionFilters,
 				ContextLines:     globalFlags.contextLines,
 			}
-			if len(args) > 0 {
-				debugArgs.Script = args[0]
+			if len(scriptArgs) > 0 {
+				debugArgs.Script = scriptArgs[0]
 			}
 
 			// Capture program args after --
-			if dashIdx := cmd.ArgsLenAtDash(); dashIdx >= 0 {
-				allArgs := cmd.Flags().Args()
-				if dashIdx < len(allArgs) {
-					debugArgs.ProgramArgs = allArgs[dashIdx:]
-				}
+			if dashIdx := cmd.ArgsLenAtDash(); dashIdx >= 0 && dashIdx < len(args) {
+				debugArgs.ProgramArgs = append([]string(nil), args[dashIdx:]...)
 			}
 
 			rawArgs, _ := json.Marshal(debugArgs)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -197,6 +197,48 @@ func TestE2E_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestE2E_DebugPython_WithProgramArgs(t *testing.T) {
+	if err := exec.Command("python3", "-c", "import debugpy").Run(); err != nil {
+		t.Skip("debugpy not installed")
+	}
+
+	env := newE2EEnv(t)
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "args.py")
+	script := `import argparse
+
+p = argparse.ArgumentParser()
+p.add_argument("value")
+args = p.parse_args()
+value = args.value
+print(value)
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	cmd := exec.Command(env.binary,
+		"--socket", env.socketPath,
+		"debug", scriptPath,
+		"--break", scriptPath+":6",
+		"--",
+		"example-value",
+	)
+	cmd.Dir = projectRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("debug with program args failed: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "Stopped: breakpoint") {
+		t.Errorf("expected breakpoint stop, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "value (str) = 'example-value'") {
+		t.Errorf("expected parsed CLI arg in locals, got:\n%s", out)
+	}
+}
+
 // TestE2E_DebugPython_Scheduler exercises cross-file breakpoints across a
 // multifile Python app: main.py → runner.py → resolver.py.
 func TestE2E_DebugPython_Scheduler(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes `dap debug` when the debugged program needs its own CLI arguments.

Before this change, Cobra treated arguments after `--` as extra positional arguments for `dap debug` itself. That caused commands like:

`dap debug script.py --break script.py:10 -- value`

to fail during CLI argument validation instead of starting a debug session and forwarding `value` to the target script.

## Root Cause

`debug` used `cobra.MaximumNArgs(1)`, which counted arguments after `--` toward the command's positional arg limit.

The command also reconstructed forwarded program args from a different slice than the one used for validation, which made the parsing logic brittle around the separator.

## Fix

- Validate only the arguments before `--`
- Use that same pre-separator slice to determine the script path
- Forward the post-separator slice directly as `ProgramArgs`

## Tests

- Added an end-to-end regression test for a Python script that requires a forwarded argument
- Verified `go test ./...` passes locally
- The new Python-specific E2E test skips unless `debugpy` is installed